### PR TITLE
Fix Ledger deployment function

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -39,7 +39,7 @@ export const getLedgerSigner = (index: number, provider: any): LedgerSigner => {
  * The package.json also uses "resolutions" to upgrade the ledger
  * dependencies to the correct version.
  */
-export const ledgerSignTransaction = async (
+export async function ledgerSignTransaction(
   transaction: ethers.providers.TransactionRequest
 ): Promise<string> => {
   const tx = await ethers.utils.resolveProperties(transaction);

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -41,7 +41,7 @@ export const getLedgerSigner = (index: number, provider: any): LedgerSigner => {
  */
 export async function ledgerSignTransaction(
   transaction: ethers.providers.TransactionRequest
-): Promise<string> => {
+): Promise<string> {
   const tx = await ethers.utils.resolveProperties(transaction);
   const baseTx: ethers.utils.UnsignedTransaction = {
     chainId: tx.chainId || undefined,


### PR DESCRIPTION
ES6 function was hiding the context of `this` which broke the deployment procedure