### PR TITLE
Conditionally run coverage CI step on PR only

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,11 @@
 name: CI
 on:
-  push:
+  pull_request:
     branches: [master]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
-  test:
+  test-coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,3 +15,7 @@ jobs:
           yarn install
           yarn test
           yarn coverage
+      - name: Post coverage report
+        uses: romeovs/lcov-reporter-action@v0.2.16
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   test-coverage:
-    if: ${{ github.event_name == "pull_request" }}
+    if: github.event_name == "pull_request"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
-    if: ${{ github.event_name == "push" }}
+    if: github.event_name == "push"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
-  test:
+  test-coverage:
+    if: ${{ github.event_name == "pull_request" }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,6 +20,16 @@ jobs:
           yarn coverage
       - name: Post coverage report
         uses: romeovs/lcov-reporter-action@v0.2.16
-        if: github.event_name == "pull_request"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+  test:
+    if: ${{ github.event_name == "push" }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run unit tests and coverage
+        run: |
+          export PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000001"
+          yarn install
+          yarn test
+          yarn coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [master]
   pull_request:
@@ -10,7 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
       - name: Run unit tests and coverage
@@ -21,5 +19,6 @@ jobs:
           yarn coverage
       - name: Post coverage report
         uses: romeovs/lcov-reporter-action@v0.2.16
+        if: ${{ github.event_name == "pull_request" }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,6 @@ jobs:
           yarn coverage
       - name: Post coverage report
         uses: romeovs/lcov-reporter-action@v0.2.16
-        if: ${{ github.event_name == "pull_request" }}
+        if: github.event_name == "pull_request"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI currently works fine on PRs but fail on merge because the `push` test runs again which also triggers the coverage step. Coverage then throws an error because it cannot proceed with posting coverage info as it is not a PR but a push to master.