### PR TITLE
Fix issue with Prettier not parsing correctly

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -32,7 +32,7 @@
         "trailingComma": "none",
         "useTabs": false,
         "vueIndentScriptAndStyle": false,
-        "parser": "babel"
+        "parser": "typescript"
       }
     }
   ]


### PR DESCRIPTION
Changed to use Typescript parser for prettier instead of Babel, which was causing all code to be treated as JS.